### PR TITLE
Add room-based connection management

### DIFF
--- a/lib/client_connections_service.dart
+++ b/lib/client_connections_service.dart
@@ -5,16 +5,21 @@ import 'package:tech_world_networking_types/tech_world_networking_types.dart';
 import 'package:tech_world_game_server/bot_user.dart';
 
 /// All of the user connections are kept by the [ClientConnectionsService] object,
-/// which keeps a map of [WebSocketChannel]s to userIds.
+/// which keeps a map of rooms, each containing WebSocketChannels to userIds.
 ///
-/// When a user connection is added or removed the [OtherPlayersMessage] is broadcast.
+/// When a user connection is added or removed the [OtherPlayersMessage] is broadcast
+/// only to users in the same room.
 class ClientConnectionsService {
   // We can constructor inject the message handler function used by shelf_web_socket
   ClientConnectionsService([Function(WebSocketChannel)? messageHandler]) {
     _messageHandler = messageHandler ?? defaultMessageHandler;
   }
 
-  final presenceMap = <WebSocketChannel, NetworkUser>{};
+  /// Map of roomId -> (WebSocketChannel -> NetworkUser)
+  final rooms = <String, Map<WebSocketChannel, NetworkUser>>{};
+
+  /// Reverse lookup: WebSocketChannel -> roomId (for cleanup on disconnect)
+  final _connectionRooms = <WebSocketChannel, String>{};
 
   // We keep the handler function as a member so that different handlers can
   // be constructor injected.
@@ -29,19 +34,24 @@ class ClientConnectionsService {
         // If a user is announcing their presence, store the webSocket against the
         // userId and broadcast the current connections
         if (jsonData['type'] == ArrivalMessage.jsonType) {
+          final roomId = jsonData['roomId'] as String;
           print(
-              'server received: $jsonString \nAdding user & broadcasting other player list');
-          _addAndBroadcast(webSocket, NetworkUser.fromJson(jsonData['user']));
+              'server received: $jsonString \nAdding user to room $roomId & broadcasting');
+          _addAndBroadcast(webSocket, NetworkUser.fromJson(jsonData['user']), roomId);
         } else if (jsonData['type'] == DepartureMessage.jsonType) {
           print(
               'server received: $jsonString \nRemoving user & broadcasting other player list');
           _removeAndBroadcast(webSocket);
         } else if (jsonData['type'] == OtherUsersMessage.jsonType) {
-          print('server received: $jsonString, broadcasting other users info');
-          _broadcastOtherUsers();
+          final roomId = _connectionRooms[webSocket];
+          if (roomId != null) {
+            print('server received: $jsonString, broadcasting other users info to room $roomId');
+            _broadcastOtherUsers(roomId);
+          }
         } else if (jsonData['type'] == PlayerPathMessage.jsonType) {
-          print('server received: $jsonString, broadcasting');
-          _broadcastPlayerPath(jsonData as Map<String, Object?>);
+          final roomId = jsonData['roomId'] as String;
+          print('server received: $jsonString, broadcasting to room $roomId');
+          _broadcastPlayerPath(jsonData as Map<String, Object?>, roomId);
         } else {
           throw Exception('Unknown json type in websocket stream: $jsonData');
         }
@@ -58,16 +68,23 @@ class ClientConnectionsService {
 
   Function(WebSocketChannel) get messageHandler => _messageHandler;
 
-  void _addAndBroadcast(WebSocketChannel ws, NetworkUser user) {
-    presenceMap[ws] = user;
-    _broadcastOtherUsers();
-    _sendBotPosition(ws);
+  void _addAndBroadcast(WebSocketChannel ws, NetworkUser user, String roomId) {
+    // Ensure room exists
+    rooms.putIfAbsent(roomId, () => {});
+    
+    // Add user to room
+    rooms[roomId]![ws] = user;
+    _connectionRooms[ws] = roomId;
+    
+    _broadcastOtherUsers(roomId);
+    _sendBotPosition(ws, roomId);
   }
 
   /// Sends the bot's position to a newly connected player.
-  void _sendBotPosition(WebSocketChannel ws) {
+  void _sendBotPosition(WebSocketChannel ws, String roomId) {
     final botPathMessage = PlayerPathMessage(
       userId: botUser.id,
+      roomId: roomId,
       points: [botPosition],
       directions: [],
     );
@@ -75,25 +92,40 @@ class ClientConnectionsService {
   }
 
   void _removeAndBroadcast(WebSocketChannel ws) {
-    presenceMap.remove(ws);
-    _broadcastOtherUsers();
+    final roomId = _connectionRooms.remove(ws);
+    if (roomId != null && rooms.containsKey(roomId)) {
+      rooms[roomId]!.remove(ws);
+      
+      // Clean up empty rooms
+      if (rooms[roomId]!.isEmpty) {
+        rooms.remove(roomId);
+      } else {
+        _broadcastOtherUsers(roomId);
+      }
+    }
   }
 
-  void _broadcastOtherUsers() {
-    for (final ws in presenceMap.keys) {
+  void _broadcastOtherUsers(String roomId) {
+    final roomConnections = rooms[roomId];
+    if (roomConnections == null) return;
+    
+    for (final ws in roomConnections.keys) {
       // make the "other players" list for this player and send
-      final users = presenceMap.values.toSet();
-      users.remove(presenceMap[ws]!);
+      final users = roomConnections.values.toSet();
+      users.remove(roomConnections[ws]!);
       users.add(botUser); // Always include the bot
       final message = jsonEncode(OtherUsersMessage(users: users));
       ws.sink.add(message);
     }
   }
 
-  void _broadcastPlayerPath(JsonMap jsonData) {
+  void _broadcastPlayerPath(JsonMap jsonData, String roomId) {
+    final roomConnections = rooms[roomId];
+    if (roomConnections == null) return;
+    
     var playerPathMessage = PlayerPathMessage.fromJson(jsonData);
-    for (final ws in presenceMap.keys) {
-      if (presenceMap[ws]!.id != playerPathMessage.userId) {
+    for (final ws in roomConnections.keys) {
+      if (roomConnections[ws]!.id != playerPathMessage.userId) {
         ws.sink.add(jsonEncode(playerPathMessage.toJson()));
       }
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -294,7 +294,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: e75995457d043d9eb5b556ebea516e8c05794260
+      resolved-ref: "82cd94637cb7e655bc03775d28ce8b73516679f4"
       url: "https://github.com/enspyrco/tech_world_networking_types"
     source: git
     version: "0.0.0+1"


### PR DESCRIPTION
## Summary
Implements room-based player isolation so players in different rooms don't see each other.

## Changes
- Changed from flat `presenceMap` to room-based `rooms` structure
- Added `_connectionRooms` reverse lookup for cleanup
- Players only see other players in their room
- Room cleanup when last player leaves
- Added test for room isolation

## Dependencies
Requires `tech_world_networking_types` with roomId in ArrivalMessage and PlayerPathMessage (already pushed).

## Testing
All 6 tests pass, including new room isolation test.